### PR TITLE
Add layout capture and card counting

### DIFF
--- a/app/blackjack.py
+++ b/app/blackjack.py
@@ -1,0 +1,42 @@
+from typing import List
+
+class CardCounter:
+    """Simple Hi-Lo card counter."""
+
+    def __init__(self) -> None:
+        self.running_count = 0
+
+    def reset(self) -> None:
+        self.running_count = 0
+
+    def add_card(self, card: str) -> None:
+        """Update running count with a single card."""
+        value = card.upper()
+        if value in ["2", "3", "4", "5", "6"]:
+            self.running_count += 1
+        elif value in ["10", "J", "Q", "K", "A"]:
+            self.running_count -= 1
+        # 7,8,9 are zero
+
+    def get_count(self) -> int:
+        return self.running_count
+
+
+def basic_strategy(player_total: int, dealer_card: str) -> str:
+    """Return a very simplified blackjack decision."""
+    dealer = dealer_card.upper()
+    if player_total >= 17:
+        return "stand"
+    if player_total >= 13 and dealer in ["2", "3", "4", "5", "6"]:
+        return "stand"
+    if player_total == 12 and dealer in ["4", "5", "6"]:
+        return "stand"
+    if player_total == 11:
+        return "double"
+    if player_total == 10 and dealer not in ["10", "A"]:
+        return "double"
+    if player_total == 9 and dealer in ["3", "4", "5", "6"]:
+        return "double"
+    if player_total <= 8:
+        return "hit"
+    return "hit"

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,37 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from .blackjack import CardCounter, basic_strategy
+
 app = FastAPI()
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 class User(BaseModel):
     id: int
     name: str
+
+
+class BoundingBox(BaseModel):
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+
+class TableLayout(BaseModel):
+    dealer: BoundingBox | None = None
+    players: list[BoundingBox] = []
 
 # Simple in-memory store for example purposes
 users_db = [
     User(id=1, name="Alice"),
     User(id=2, name="Bob"),
 ]
+
+card_counter = CardCounter()
+table_layout = TableLayout()
 
 @app.get("/")
 def read_root():
@@ -20,3 +40,53 @@ def read_root():
 @app.get("/users", response_model=list[User])
 def read_users():
     return users_db
+
+
+@app.get("/draw", response_class=HTMLResponse)
+def draw_page(request: Request):
+    with open("app/static/draw.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+
+@app.post("/layout", response_model=TableLayout)
+def set_layout(layout: TableLayout):
+    global table_layout
+    table_layout = layout
+    return table_layout
+
+
+@app.get("/layout", response_model=TableLayout)
+def get_layout():
+    return table_layout
+
+
+@app.post("/reset_count")
+def reset_count():
+    card_counter.reset()
+    return {"count": card_counter.get_count()}
+
+
+class CardInput(BaseModel):
+    card: str
+
+
+@app.post("/count")
+def add_card(input: CardInput):
+    card_counter.add_card(input.card)
+    return {"count": card_counter.get_count()}
+
+
+@app.get("/count")
+def get_count():
+    return {"count": card_counter.get_count()}
+
+
+class SuggestInput(BaseModel):
+    player_total: int
+    dealer_card: str
+
+
+@app.post("/suggest")
+def suggest_action(input: SuggestInput):
+    action = basic_strategy(input.player_total, input.dealer_card)
+    return {"action": action}

--- a/app/static/draw.html
+++ b/app/static/draw.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Table Layout</title>
+  <style>
+    canvas { border:1px solid #000; }
+  </style>
+</head>
+<body>
+<h1>Draw card boxes</h1>
+<p>Upload a table screenshot and draw rectangles for dealer and players. Press Save to send layout.</p>
+<input type="file" id="imgInput" accept="image/*"><br><br>
+<canvas id="canvas"></canvas><br>
+<button id="save">Save Layout</button>
+<script>
+let canvas = document.getElementById('canvas');
+let ctx = canvas.getContext('2d');
+let img = new Image();
+let drawing = false;
+let startX, startY;
+let boxes = [];
+
+img.onload = function() {
+  canvas.width = img.width;
+  canvas.height = img.height;
+  ctx.drawImage(img,0,0);
+};
+
+document.getElementById('imgInput').onchange = function(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = function(evt) {
+    img.src = evt.target.result;
+  };
+  reader.readAsDataURL(file);
+};
+
+canvas.onmousedown = function(e){
+  drawing = true;
+  startX = e.offsetX; startY = e.offsetY;
+};
+
+canvas.onmouseup = function(e){
+  if(!drawing) return;
+  drawing = false;
+  const x2 = e.offsetX; const y2 = e.offsetY;
+  boxes.push({x1:startX,y1:startY,x2:x2,y2:y2});
+  redraw();
+};
+
+function redraw(){
+  ctx.drawImage(img,0,0);
+  ctx.strokeStyle = 'red';
+  boxes.forEach(b=>{
+    ctx.strokeRect(b.x1,b.y1,b.x2-b.x1,b.y2-b.y1);
+  });
+}
+
+document.getElementById('save').onclick = function(){
+  fetch('/layout', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({dealer:boxes[0], players:boxes.slice(1)})
+  }).then(r=>alert('Saved layout')); 
+};
+</script>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,3 +20,16 @@ def test_read_users():
     assert isinstance(data, list)
     assert data
     assert all("id" in user and "name" in user for user in data)
+
+
+def test_reset_count():
+    response = client.post("/reset_count")
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+def test_suggest_action():
+    payload = {"player_total": 11, "dealer_card": "6"}
+    response = client.post("/suggest", json=payload)
+    assert response.status_code == 200
+    assert response.json()["action"] in {"hit", "stand", "double"}


### PR DESCRIPTION
## Summary
- add `CardCounter` and basic strategy helpers
- implement layout endpoints and card-count API
- serve simple HTML page for drawing card regions
- include reset and suggestion endpoints with tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866f3c20ea0832d9984be71bb2963e4