### PR TITLE
Improve docs, tests and layout editor

### DIFF
--- a/app/blackjack.py
+++ b/app/blackjack.py
@@ -1,7 +1,13 @@
+"""Blackjack utilities used by the API."""
+
 from typing import List
 
 class CardCounter:
-    """Simple Hi-Lo card counter."""
+    """Simple Hi-Lo card counter.
+
+    The counter is stateful and not thread-safe, so it should be instantiated
+    per-session or protected appropriately when used in a web context.
+    """
 
     def __init__(self) -> None:
         self.running_count = 0
@@ -23,7 +29,15 @@ class CardCounter:
 
 
 def basic_strategy(player_total: int, dealer_card: str) -> str:
-    """Return a very simplified blackjack decision."""
+    """Return a very simplified blackjack decision.
+
+    Parameters
+    ----------
+    player_total: int
+        Current total of the player's hand.
+    dealer_card: str
+        Visible dealer card.
+    """
     dealer = dealer_card.upper()
     if player_total >= 17:
         return "stand"

--- a/app/static/draw.html
+++ b/app/static/draw.html
@@ -4,15 +4,41 @@
   <meta charset="UTF-8" />
   <title>Table Layout</title>
   <style>
-    canvas { border:1px solid #000; }
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 800px;
+      margin: auto;
+      padding: 1em;
+      background: #f5f5f5;
+    }
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+    #controls {
+      margin-bottom: 1em;
+      text-align: center;
+    }
+    canvas {
+      border: 1px solid #444;
+      display: block;
+      margin: auto;
+    }
+    button {
+      margin-top: 0.5em;
+      padding: 0.5em 1em;
+      font-size: 1em;
+    }
   </style>
 </head>
 <body>
-<h1>Draw card boxes</h1>
-<p>Upload a table screenshot and draw rectangles for dealer and players. Press Save to send layout.</p>
-<input type="file" id="imgInput" accept="image/*"><br><br>
-<canvas id="canvas"></canvas><br>
-<button id="save">Save Layout</button>
+<h1>Table Layout Editor</h1>
+<div id="controls">
+  <p>Upload a screenshot of the table and draw rectangles for the dealer and players. The first box will be used for the dealer position.</p>
+  <input type="file" id="imgInput" accept="image/*"><br>
+  <button id="save">Save Layout</button>
+</div>
+<canvas id="canvas"></canvas>
 <script>
 let canvas = document.getElementById('canvas');
 let ctx = canvas.getContext('2d');

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,3 +33,31 @@ def test_suggest_action():
     response = client.post("/suggest", json=payload)
     assert response.status_code == 200
     assert response.json()["action"] in {"hit", "stand", "double"}
+
+
+def test_layout_roundtrip():
+    layout = {
+        "dealer": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+        "players": [{"x1": 1, "y1": 1, "x2": 5, "y2": 5}],
+    }
+    response = client.post("/layout", json=layout)
+    assert response.status_code == 200
+    assert response.json() == layout
+
+    response = client.get("/layout")
+    assert response.status_code == 200
+    assert response.json() == layout
+
+
+def test_count_endpoints():
+    client.post("/reset_count")
+    client.post("/count", json={"card": "A"})
+    response = client.get("/count")
+    assert response.status_code == 200
+    assert response.json()["count"] == -1
+
+
+def test_draw_page():
+    response = client.get("/draw")
+    assert response.status_code == 200
+    assert "Table Layout" in response.text


### PR DESCRIPTION
## Summary
- document blackjack module
- add full docstrings for endpoints
- use absolute static path and safer Pydantic defaults
- polish layout editor UI
- expand API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f48a4398832d9d1ac00631f02170