### PR TITLE
Add true count tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Progress bar legend → ⬜ 0 % · ▣ 25 % · ◧ 50 % · ◩ 75 % · ■ 100 %
 | T-03 | Implement endpoint `/users` | Backend-Agent | T-02         | ■ 100 % | Returns list of `User` models |
 | T-04 | Unit tests for `/users`     | QA-Agent      | T-03         | ■ 100 % | pytest covering endpoints |
 | T-05 | Set up FastAPI skeleton     | Implementation-Agent | T-01 | ■ 100 % | FastAPI app with endpoints |
+| T-06 | True count endpoint         | Backend-Agent | T-05 | ■ 100 % | Adds `/decks` and `/true_count` |
 | …    | …                           | …             | …            | …      | …     |
 
 > **How to update:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # BlackJackCVBot
 
-This project is a simple FastAPI service for demonstrating multi-agent collaboration workflows. It exposes a `/` root endpoint and a `/users` endpoint returning a list of example users.
+This project is a simple FastAPI service for demonstrating multi-agent collaboration workflows. It exposes:
+
+* `/` — health check
+* `/users` — list of example users
+* `/count` — manage a running Hi-Lo count
+* `/decks` — configure number of decks for true count
+* `/true_count` — retrieve the current true count
 
 ## Running the server
 

--- a/app/blackjack.py
+++ b/app/blackjack.py
@@ -1,19 +1,26 @@
 """Blackjack utilities used by the API."""
 
-from typing import List
 
 class CardCounter:
-    """Simple Hi-Lo card counter.
+    """Simple Hi-Lo card counter with true count support.
 
     The counter is stateful and not thread-safe, so it should be instantiated
     per-session or protected appropriately when used in a web context.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, decks: int = 1) -> None:
         self.running_count = 0
+        self.cards_dealt = 0
+        self.num_decks = decks
 
     def reset(self) -> None:
         self.running_count = 0
+        self.cards_dealt = 0
+
+    def set_decks(self, decks: int) -> None:
+        """Configure number of decks used for true count calculations."""
+        self.num_decks = max(1, decks)
+        self.cards_dealt = 0
 
     def add_card(self, card: str) -> None:
         """Update running count with a single card."""
@@ -23,9 +30,17 @@ class CardCounter:
         elif value in ["10", "J", "Q", "K", "A"]:
             self.running_count -= 1
         # 7,8,9 are zero
+        self.cards_dealt += 1
 
     def get_count(self) -> int:
         return self.running_count
+
+    def get_true_count(self) -> float:
+        """Return the Hi-Lo true count as a floating point number."""
+        decks_remaining = ((self.num_decks * 52) - self.cards_dealt) / 52
+        if decks_remaining <= 0:
+            decks_remaining = 1
+        return self.running_count / decks_remaining
 
 
 def basic_strategy(player_total: int, dealer_card: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -102,8 +102,25 @@ class SuggestInput(BaseModel):
     dealer_card: str
 
 
+class DeckConfig(BaseModel):
+    decks: int
+
+
 @app.post("/suggest")
 def suggest_action(input: SuggestInput):
     """Return basic-strategy advice based on totals."""
     action = basic_strategy(input.player_total, input.dealer_card)
     return {"action": action}
+
+
+@app.post("/decks")
+def set_decks(config: DeckConfig):
+    """Configure the number of decks used for true count calculations."""
+    card_counter.set_decks(config.decks)
+    return {"decks": card_counter.num_decks}
+
+
+@app.get("/true_count")
+def get_true_count():
+    """Return the current Hi-Lo true count."""
+    return {"true_count": card_counter.get_true_count()}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,17 @@ def test_count_endpoints():
     assert response.json()["count"] == -1
 
 
+def test_decks_and_true_count():
+    client.post("/decks", json={"decks": 1})
+    client.post("/reset_count")
+    client.post("/count", json={"card": "5"})
+    response = client.get("/true_count")
+    assert response.status_code == 200
+    true_count = response.json()["true_count"]
+    assert isinstance(true_count, float)
+    assert true_count > 1
+
+
 def test_draw_page():
     response = client.get("/draw")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- extend `CardCounter` to track decks dealt and compute true count
- add `/decks` and `/true_count` API endpoints
- cover new functionality in tests
- update docs and AGENTS tracker

## Testing
- `pytest -q`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_6866f65cf3c8832db5c19eb05b4ccdaa