### PR TITLE
feat: add NUM_DECKS env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+Set `NUM_DECKS` to configure the number of decks used for true count
+calculations at startup:
+
+```bash
+NUM_DECKS=6 uvicorn app.main:app --reload
+```
+
 ## Running tests
 
 Execute the unit tests with pytest:

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 """Main FastAPI application exposing card counting endpoints."""
 
 from pathlib import Path
+import os
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -38,7 +39,8 @@ users_db = [
     User(id=2, name="Bob"),
 ]
 
-card_counter = CardCounter()
+num_decks = int(os.getenv("NUM_DECKS", "1"))
+card_counter = CardCounter(decks=num_decks)
 table_layout = TableLayout()
 
 @app.get("/")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,15 @@
+import os
+import importlib
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+def test_num_decks_env():
+    os.environ["NUM_DECKS"] = "6"
+    import app.main as main
+    importlib.reload(main)
+    client = TestClient(main.app)
+    assert main.card_counter.num_decks == 6
+    os.environ.pop("NUM_DECKS", None)
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- configure `CardCounter` deck count via `NUM_DECKS`
- document environment variable in README
- verify env var behavior with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f76cbc44832dabc1cfb83025715d