### PR TITLE
Fix dealer card alias handling

### DIFF
--- a/app/blackjack.py
+++ b/app/blackjack.py
@@ -100,7 +100,8 @@ def basic_strategy(player_total: int, dealer_card: str) -> str:
     dealer_card: str
         Visible dealer card.
     """
-    dealer = dealer_card.upper()
+    dealer_norm = normalize_card(dealer_card)
+    dealer = dealer_norm if dealer_norm is not None else dealer_card.upper()
     if player_total >= 17:
         return "stand"
     if player_total >= 13 and dealer in ["2", "3", "4", "5", "6"]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,13 @@ def test_suggest_action():
     assert response.json()["action"] in {"hit", "stand", "double"}
 
 
+def test_suggest_action_alias():
+    payload = {"player_total": 10, "dealer_card": "Ace of Spades"}
+    response = client.post("/suggest", json=payload)
+    assert response.status_code == 200
+    assert response.json()["action"] == "hit"
+
+
 def test_layout_roundtrip():
     layout = {
         "dealer": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},


### PR DESCRIPTION
## Summary
- normalize dealer card input for `basic_strategy`
- test alias input for `/suggest` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f9c56a0c832db8dc87d643a2a087