### PR TITLE
Add OCR-based card recognition endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is a simple FastAPI service for demonstrating multi-agent collabora
   will be parsed correctly.
 * `/decks` — configure number of decks for true count
 * `/true_count` — retrieve the current true count
+* `/recognize_card` — OCR endpoint that detects a card value from an uploaded image
 
 ## Running the server
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import os
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, UploadFile
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -10,6 +10,7 @@ from pydantic.dataclasses import dataclass
 from fastapi.encoders import jsonable_encoder
 
 from .blackjack import CardCounter, basic_strategy
+from .vision import recognize_card, recognize_card_bytes
 
 # Resolve path to static files relative to this file so the app works when
 # executed from any working directory.
@@ -131,3 +132,11 @@ def set_decks(config: DeckConfig):
 def get_true_count():
     """Return the current Hi-Lo true count."""
     return {"true_count": card_counter.get_true_count()}
+
+
+@app.post("/recognize_card")
+async def recognize_card_endpoint(file: UploadFile):
+    """Detect and normalize a card value from an uploaded image."""
+    data = await file.read()
+    card = recognize_card_bytes(data)
+    return {"card": card}

--- a/app/vision.py
+++ b/app/vision.py
@@ -1,0 +1,27 @@
+"""Utility functions for recognizing card values from images."""
+
+from io import BytesIO
+from typing import Optional
+
+from PIL import Image
+import pytesseract
+
+from .blackjack import normalize_card
+
+
+def recognize_card(image: Image.Image) -> Optional[str]:
+    """Return canonical card value detected in the given image.
+
+    The detection uses Tesseract OCR to read any text in the image and then
+    maps it to the internal card representation using :func:`normalize_card`.
+    """
+    text = pytesseract.image_to_string(image, config="--psm 6").strip()
+    if not text:
+        return None
+    return normalize_card(text)
+
+
+def recognize_card_bytes(data: bytes) -> Optional[str]:
+    """Convenience wrapper that accepts raw image bytes."""
+    with Image.open(BytesIO(data)) as img:
+        return recognize_card(img)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pygetwindow
 pytesseract
 Pillow
 pyttsx3
+python-multipart

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+from PIL import Image, ImageDraw, ImageFont
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def generate_card_image(text: str) -> bytes:
+    img = Image.new("RGB", (200, 200), "white")
+    try:
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 120)
+    except Exception:
+        font = ImageFont.load_default()
+    draw = ImageDraw.Draw(img)
+    draw.text((40, 40), text, fill="black", font=font)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_recognize_card_endpoint():
+    data = generate_card_image("A")
+    response = client.post(
+        "/recognize_card",
+        files={"file": ("card.png", data, "image/png")},
+    )
+    assert response.status_code == 200
+    assert response.json()["card"] == "A"


### PR DESCRIPTION
## Summary
- add `app/vision.py` with OCR helper functions
- expose `/recognize_card` endpoint that accepts image uploads
- document the new endpoint in the README
- include Python multipart dependency
- add unit tests for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686701a30228832d9b292c523fbb29d4